### PR TITLE
Add syntax option for syntax highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ $ uname -a | nidobata post my-org-slug my-room
 $ cat README.md | nidobata post my-org-slug my-room --pre
 ```
 
+`--syntax` option surronds input with triple tildes(`~~~`) with syntax name.
+:warning: It does not work when including triple backquotes or triple tildes in input text :warning:
+
+```
+$ cat lib/nidobata/version.rb | nidobata post my-org-slug my-room --syntax ruby
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/README.md
+++ b/README.md
@@ -19,17 +19,11 @@ Password: ⏎
 $ uname -a | nidobata post my-org-slug my-room
 ```
 
-`--pre` option surrounds input with `<pre></pre>`.
+`--pre` option surrounds input with triple tildes(`~~~`) and syntax name.
+:warning: It does not work when including triple tildes in input text :warning:
 
 ```
-$ cat README.md | nidobata post my-org-slug my-room --pre
-```
-
-`--syntax` option surronds input with triple tildes(`~~~`) with syntax name.
-:warning: It does not work when including triple backquotes or triple tildes in input text :warning:
-
-```
-$ cat lib/nidobata/version.rb | nidobata post my-org-slug my-room --syntax ruby
+$ cat README.md | nidobata post my-org-slug my-room --pre markdown
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ uname -a | nidobata post my-org-slug my-room
 ```
 
 `--pre` option surrounds input with triple tildes(`~~~`) and syntax name.
-:warning: It does not work when including triple tildes in input text :warning:
+:warning: It does not work when including triple backquotes or triple tildes in input text :warning:
 
 ```
 $ cat README.md | nidobata post my-org-slug my-room --pre markdown

--- a/lib/nidobata.rb
+++ b/lib/nidobata.rb
@@ -93,7 +93,7 @@ module Nidobata
           if pre
             "<pre>\n#{original_message}</pre>"
           elsif syntax
-            "```#{syntax}\n#{original_message}\n```"
+            "~~~#{syntax}\n#{original_message}\n~~~"
           else
             original_message
           end

--- a/lib/nidobata.rb
+++ b/lib/nidobata.rb
@@ -23,8 +23,8 @@ module Nidobata
     end
 
     desc 'post ORG_SLUG ROOM_NAME [MESSAGE] [--pre] [--title]', 'Post a message from stdin or 2nd argument.'
-    option :pre,    type: :string, lazy_default: '', desc: 'can be used syntax highlight if argument exists'
-    option :title,  type: :string, default: nil
+    option :pre,   type: :string, lazy_default: '', desc: 'can be used syntax highlight if argument exists'
+    option :title, type: :string, default: nil
     def post(slug, room_name, message = $stdin.read)
       abort 'Message is required.' unless message
       ensure_api_token

--- a/lib/nidobata.rb
+++ b/lib/nidobata.rb
@@ -34,6 +34,7 @@ module Nidobata
 
       message = build_message(message, options)
       payload = {room_id: room_id, source: message}
+      payload[:format] = 'markdown' if options[:pre]
 
       http.post('/api/messages', payload.to_json, default_headers).value
     end


### PR DESCRIPTION
usege:
```
$ cat lib/nidobata/version.rb | nidobata post my-org-slug my-room --syntax ruby
```

![idobata io_ _organization_kunitoo_room_hi](https://cloud.githubusercontent.com/assets/490213/21953401/faada33c-da78-11e6-89de-4f7f59f08d24.png)

If you specify the syntax for the pre option,
the behavior will change in the markdown file containing triple backquote(```),
so I added a new option.