### PR TITLE
Add `format` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ $ uname -a | nidobata post my-org-slug my-room
 $ cat README.md | nidobata post my-org-slug my-room --pre markdown
 ```
 
+If you want to post it as just markdown, not as syntax highlighted text as markdown:
+
+```
+$ cat README.md | nidobata post my-org-slug my-room --format MARKDOWN
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
@@ -40,4 +46,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/idobat
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/lib/nidobata.rb
+++ b/lib/nidobata.rb
@@ -67,9 +67,10 @@ module Nidobata
       end
     end
 
-    desc 'post ORG_SLUG ROOM_NAME [MESSAGE] [--pre] [--title]', 'Post a message from stdin or 2nd argument.'
-    option :pre,   type: :string, lazy_default: '', desc: 'can be used syntax highlight if argument exists'
-    option :title, type: :string, default: nil
+    desc 'post ORG_SLUG ROOM_NAME [MESSAGE] [--pre] [--title] [--format]', 'Post a message from stdin or 2nd argument.'
+    option :pre,    type: :string, lazy_default: '', desc: 'can be used syntax highlight if argument exists'
+    option :title,  type: :string, default: nil
+    option :format, type: :string, default: nil, desc: 'it is ignored if pre argument exists'
     def post(slug, room_name, message = $stdin.read)
       abort 'Message is required.' unless message
       ensure_api_token
@@ -81,7 +82,8 @@ module Nidobata
       payload = {
         roomId: room_id,
         source: build_message(message, options),
-        format: options[:pre] ? 'MARKDOWN' : 'PLAIN'
+        format: options[:pre] ? 'MARKDOWN' :
+                options[:format] ? options[:format] : 'PLAIN'
       }
 
       query CreateMessageMutation, variables: {input: payload}


### PR DESCRIPTION
I'd like to post a message to Idobata as markdown, so I added the `format` option. 
```sh
$ curl https://api.github.com/repos/idobata/nidobata/issues?state=all |\
jq -r '.[] | [.state, .title, .url] | @tsv' |\
awk -F"\t" '{ state = $1 == "open" ? " " : "x" } { printf "- [%s] [%s](%s)\n", state, $2, $3 }' |\
sed 1i'## issues' |\
nidobata post my-org-slug my-room-name --format MARKDOWN
```
If the `pre` option exists, It takes precedence.

I'm sorry if there are English mistakes :bowing_man: 